### PR TITLE
Fix typo in Kaltura copyright license header

### DIFF
--- a/library/Kaltura/Client/Client.php
+++ b/library/Kaltura/Client/Client.php
@@ -6,7 +6,7 @@
 //                          |_|\_\__,_|_|\__|\_,_|_| \__,_|
 //
 // This file is part of the Kaltura Collaborative Media Suite which allows users
-// to do with audio, video, and animation what Wiki platfroms allow them to do with
+// to do with audio, video, and animation what Wiki platforms allow them to do with
 // text.
 //
 // Copyright (C) 2006-2021  Kaltura Inc.


### PR DESCRIPTION
This misspelling occurs in nearly all generated source files, so it may need to be corrected in an external automation or build pipeline.